### PR TITLE
fix: remove 7-day limit on sale date entry

### DIFF
--- a/src/components/pages/sales/SaleForm.tsx
+++ b/src/components/pages/sales/SaleForm.tsx
@@ -178,17 +178,6 @@ export function SaleForm({ db, initial, onClose, onSave, selectedBranchId }: Sal
       return;
     }
 
-    // Validate sale date is not more than 1 week in the past
-    const selectedDate = new Date(saleDate);
-    const oneWeekAgo = new Date();
-    oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
-    oneWeekAgo.setHours(0, 0, 0, 0);
-
-    if (selectedDate < oneWeekAgo) {
-      alert(t('sales.dateCannotBeMoreThanWeekOld'));
-      return;
-    }
-
     // Convert YYYY-MM-DD to ISO timestamp, preserving time if editing
     const saleDateISO = initial?.createdAt
       ? new Date(saleDate + 'T' + initial.createdAt.split('T')[1]).toISOString()

--- a/src/hooks/useAppData.ts
+++ b/src/hooks/useAppData.ts
@@ -344,100 +344,109 @@ export function useAppData() {
         throw err;
       }
     },
-    []
+    [refreshData]
   );
 
-  const removePurchase = useCallback(async (id: string, restoredItems: InventoryItem[]) => {
-    const snapshot = dbRef.current;
-    setDb(prev => {
-      let nextItems = [...prev.items];
-      restoredItems.forEach(ri => {
-        nextItems = nextItems.map(it =>
-          it.id === ri.id && (it.branchId ?? null) === (ri.branchId ?? null) ? ri : it
-        );
+  const removePurchase = useCallback(
+    async (id: string, restoredItems: InventoryItem[]) => {
+      const snapshot = dbRef.current;
+      setDb(prev => {
+        let nextItems = [...prev.items];
+        restoredItems.forEach(ri => {
+          nextItems = nextItems.map(it =>
+            it.id === ri.id && (it.branchId ?? null) === (ri.branchId ?? null) ? ri : it
+          );
+        });
+        return { ...prev, purchases: prev.purchases.filter(p => p.id !== id), items: nextItems };
       });
-      return { ...prev, purchases: prev.purchases.filter(p => p.id !== id), items: nextItems };
-    });
-    let remoteWriteStarted = false;
-    try {
-      remoteWriteStarted = true;
-      await deletePurchaseApi(id);
-      await Promise.all(restoredItems.map(item => upsertProduct(item)));
-    } catch (err) {
-      if (remoteWriteStarted) {
-        refreshData();
-      } else {
-        setDb(snapshot);
+      let remoteWriteStarted = false;
+      try {
+        remoteWriteStarted = true;
+        await deletePurchaseApi(id);
+        await Promise.all(restoredItems.map(item => upsertProduct(item)));
+      } catch (err) {
+        if (remoteWriteStarted) {
+          refreshData();
+        } else {
+          setDb(snapshot);
+        }
+        throw err;
       }
-      throw err;
-    }
-  }, []);
+    },
+    [refreshData]
+  );
 
   // --- Sale ---
 
-  const saveSale = useCallback(async (sale: Sale, updatedItems: InventoryItem[]) => {
-    const tempId = sale.id;
-    const snapshot = dbRef.current;
-    setDb(prev => {
-      const exists = prev.sales.find(s => s.id === tempId);
-      const nextSales = exists
-        ? prev.sales.map(s => (s.id === tempId ? sale : s))
-        : [...prev.sales, sale];
+  const saveSale = useCallback(
+    async (sale: Sale, updatedItems: InventoryItem[]) => {
+      const tempId = sale.id;
+      const snapshot = dbRef.current;
+      setDb(prev => {
+        const exists = prev.sales.find(s => s.id === tempId);
+        const nextSales = exists
+          ? prev.sales.map(s => (s.id === tempId ? sale : s))
+          : [...prev.sales, sale];
 
-      let nextItems = [...prev.items];
-      updatedItems.forEach(ui => {
-        nextItems = nextItems.map(it =>
-          it.id === ui.id && (it.branchId ?? null) === (ui.branchId ?? null) ? ui : it
-        );
+        let nextItems = [...prev.items];
+        updatedItems.forEach(ui => {
+          nextItems = nextItems.map(it =>
+            it.id === ui.id && (it.branchId ?? null) === (ui.branchId ?? null) ? ui : it
+          );
+        });
+
+        return { ...prev, sales: nextSales, items: nextItems };
       });
-
-      return { ...prev, sales: nextSales, items: nextItems };
-    });
-    let remoteWriteStarted = false;
-    try {
-      remoteWriteStarted = true;
-      const dbId = await upsertSaleWithRelations(sale, updatedItems);
-      if (dbId !== tempId) {
-        setDb(prev => ({
-          ...prev,
-          sales: prev.sales.map(s => (s.id === tempId ? { ...s, id: dbId } : s)),
-        }));
+      let remoteWriteStarted = false;
+      try {
+        remoteWriteStarted = true;
+        const dbId = await upsertSaleWithRelations(sale, updatedItems);
+        if (dbId !== tempId) {
+          setDb(prev => ({
+            ...prev,
+            sales: prev.sales.map(s => (s.id === tempId ? { ...s, id: dbId } : s)),
+          }));
+        }
+      } catch (err) {
+        if (remoteWriteStarted) {
+          refreshData();
+        } else {
+          setDb(snapshot);
+        }
+        throw err;
       }
-    } catch (err) {
-      if (remoteWriteStarted) {
-        refreshData();
-      } else {
-        setDb(snapshot);
-      }
-      throw err;
-    }
-  }, []);
+    },
+    [refreshData]
+  );
 
-  const removeSale = useCallback(async (id: string, restoredItems: InventoryItem[]) => {
-    const snapshot = dbRef.current;
-    setDb(prev => {
-      let nextItems = [...prev.items];
-      restoredItems.forEach(ri => {
-        nextItems = nextItems.map(it =>
-          it.id === ri.id && (it.branchId ?? null) === (ri.branchId ?? null) ? ri : it
-        );
+  const removeSale = useCallback(
+    async (id: string, restoredItems: InventoryItem[]) => {
+      const snapshot = dbRef.current;
+      setDb(prev => {
+        let nextItems = [...prev.items];
+        restoredItems.forEach(ri => {
+          nextItems = nextItems.map(it =>
+            it.id === ri.id && (it.branchId ?? null) === (ri.branchId ?? null) ? ri : it
+          );
+        });
+        return { ...prev, sales: prev.sales.filter(s => s.id !== id), items: nextItems };
       });
-      return { ...prev, sales: prev.sales.filter(s => s.id !== id), items: nextItems };
-    });
-    let remoteWriteStarted = false;
-    try {
-      remoteWriteStarted = true;
-      await deleteSaleApi(id);
-      await Promise.all(restoredItems.map(item => upsertProduct(item)));
-    } catch (err) {
-      if (remoteWriteStarted) {
-        refreshData();
-      } else {
-        setDb(snapshot);
+      let remoteWriteStarted = false;
+      try {
+        remoteWriteStarted = true;
+        await deleteSaleApi(id);
+        await Promise.all(restoredItems.map(item => upsertProduct(item)));
+      } catch (err) {
+        if (remoteWriteStarted) {
+          refreshData();
+        } else {
+          setDb(snapshot);
+        }
+        throw err;
       }
-      throw err;
-    }
-  }, []);
+    },
+    [refreshData]
+  );
 
   return {
     db,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -228,7 +228,6 @@
     "unitPrice": "Unit Price",
     "range": "Range",
     "saleDate": "Sale Date",
-    "dateCannotBeMoreThanWeekOld": "Sale date cannot be more than 1 week in the past",
     "buyerName": "Buyer Name (optional)",
     "enterCustomerName": "Enter customer name...",
     "salesChannel": "Sales Channel (optional)",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -226,7 +226,6 @@
     "unitPrice": "Precio Unitario",
     "range": "Rango",
     "saleDate": "Fecha de Venta",
-    "dateCannotBeMoreThanWeekOld": "La fecha de venta no puede ser más de 1 semana en el pasado",
     "buyerName": "Nombre del Comprador (opcional)",
     "enterCustomerName": "Ingresar nombre del cliente...",
     "salesChannel": "Canal de Ventas (opcional)",


### PR DESCRIPTION
## Summary
- Removes the frontend-only validation that blocked sale dates more than 7 days in the past
- Removes unused `sales.dateCannotBeMoreThanWeekOld` strings from EN/ES locales
- Keeps `max={today}` on the sale date input so future dates are still blocked in the picker

## Test plan
- [ ] Register a sale with a date 35+ days in the past — saves without alert
- [ ] Register a sale dated today — still works
- [ ] Confirm date picker cannot select a future date
- [ ] Edit an existing sale older than 7 days and save successfully

Made with [Cursor](https://cursor.com)