### PR TITLE
fix: preserve branch and location IDs when saving inventory edits

### DIFF
--- a/src/components/pages/inventory/InventoryForm.tsx
+++ b/src/components/pages/inventory/InventoryForm.tsx
@@ -86,6 +86,8 @@ export function InventoryForm({ initial, brands, onClose, onSave }: InventoryFor
       isActive,
       minProfit,
       maxProfit,
+      branchId: initial?.branchId,
+      locationInventoryId: initial?.locationInventoryId,
       createdAt: initial?.createdAt ?? nowIso(),
       updatedAt: nowIso(),
     };


### PR DESCRIPTION
## Summary
- When saving an inventory item edit, preserve `branchId` and `locationInventoryId` from the existing record
- Prevents branch-scoped inventory associations from being dropped on save

## Test plan
- [ ] Edit an inventory item at a branch location and save — branch/location IDs unchanged
- [ ] Create a new inventory item — behavior unchanged (no initial branch IDs)

Made with [Cursor](https://cursor.com)