### PR TITLE
Fix transaction card payment source label

### DIFF
--- a/src/components/pages/transactions/TransactionsPage.tsx
+++ b/src/components/pages/transactions/TransactionsPage.tsx
@@ -6,7 +6,10 @@ import { RevenueService } from '../../../lib/revenueService';
 import { TransactionForm } from './TransactionForm';
 import { DateFilters, DateFilterOption } from '../../molecules/DateFilters';
 import { RevenueWithdrawals } from '../../RevenueWithdrawals';
-import { getTransactionCategoryTranslationKey } from '../../../lib/transactionUtils';
+import {
+  getPaymentSourceTranslationKey,
+  getTransactionCategoryTranslationKey,
+} from '../../../lib/transactionUtils';
 
 interface TransactionsPageProps {
   db: DB;
@@ -210,18 +213,18 @@ export function TransactionsPage({
                 <div className="grid two">
                   <div>
                     <b>{t('transactions.sourceLabel')}:</b>{' '}
-                    {transaction.paymentSource === 'mixed'
-                      ? t('transactions.mixedSources')
-                      : transaction.paymentSource === 'revenue'
-                        ? t('transactions.businessRevenue')
-                        : t('transactions.externalFunds')}
+                    {transaction.paymentSource
+                      ? t(
+                          `transactions.${getPaymentSourceTranslationKey(transaction.paymentSource)}`
+                        )
+                      : t('transactions.notSpecified')}
                   </div>
                   {transaction.paymentSource === 'mixed' &&
                     transaction.cashAmount &&
                     transaction.externalAmount && (
                       <div>
                         <b>{t('transactions.breakdownLabel')}:</b> {fmtUSD(transaction.cashAmount)}{' '}
-                        {t('transactions.businessRevenue').toLowerCase()} +{' '}
+                        {t('transactions.businessCash').toLowerCase()} +{' '}
                         {fmtUSD(transaction.externalAmount)}{' '}
                         {t('transactions.externalFunds').toLowerCase()}
                       </div>

--- a/src/lib/transactionUtils.ts
+++ b/src/lib/transactionUtils.ts
@@ -1,3 +1,15 @@
+import { PaymentSource } from '../types/models';
+
+const PAYMENT_SOURCE_TRANSLATION_KEYS: Record<PaymentSource, string> = {
+  external: 'externalFunds',
+  revenue: 'businessCash',
+  mixed: 'mixedSources',
+};
+
+/** Maps payment source values to transactions.* i18n keys */
+export const getPaymentSourceTranslationKey = (source: PaymentSource): string =>
+  PAYMENT_SOURCE_TRANSLATION_KEYS[source];
+
 /**
  * Maps transaction category keys to translation keys
  */


### PR DESCRIPTION
## Summary

- Fixes expense/fee transaction cards showing `Source: transactions.businessRevenue` (raw i18n key) instead of a translated label.
- Adds `getPaymentSourceTranslationKey()` in `transactionUtils.ts` so card display uses the same locale keys as `TransactionForm` (`businessCash`, `externalFunds`, `mixedSources`).
- Updates mixed-payment breakdown copy to use `businessCash` instead of the non-existent `businessRevenue` key.

## Test plan

- [ ] Open Business Transactions and confirm an expense or fee card with payment source **Business Cash** shows `Source: Business Cash` (not a raw key).
- [ ] Confirm **External Funds** and **Mixed Sources** labels render correctly on other cards.
- [ ] For a mixed-source transaction, verify the breakdown line uses lowercase “business cash” and “external funds”.
- [ ] Switch app language to Spanish and confirm source labels still translate correctly.


Made with [Cursor](https://cursor.com)